### PR TITLE
res.send(status, body) is depricated in express, changing to send.status...

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ exports.post = function (req, res) {
     createdAt: new Date()
   }, function (err, data) {
     if (err) {
-      res.send(500, "Something went wrong: " + err.message);
+      res.status(500).send("Something went wrong: " + err.message);
     } else {
       res.send(data);
     }

--- a/lib/handlersParser.js
+++ b/lib/handlersParser.js
@@ -47,9 +47,9 @@ Handler.prototype.func = function (direct) {
       /* Pass along the error to the client */
       var status = err.statusCode || 500;
       if (productionMode() && !err.public) {
-        res.send(status, 'An error occurred');
+        res.status(status).send('An error occurred');
       } else {
-        res.send(status, err.message || err);
+        res.status(status).send(err.message || err);
       }
     });
   };

--- a/test/synth_app.js
+++ b/test/synth_app.js
@@ -149,7 +149,7 @@ describe('synth-api module', function () {
           app: app,
           timeout: 100,
           catchAll: function (req, res) {
-            res.send(404, 'this is not the data you are looking for');
+            res.status(404).send('this is not the data you are looking for');
           }
         });
     });


### PR DESCRIPTION
...(status).send(body) see: https://github.com/strongloop/express/issues/2227
